### PR TITLE
Fix dead and alive players z-index order in radar

### DIFF
--- a/src/HUD/Radar/LexoRadar/index.css
+++ b/src/HUD/Radar/LexoRadar/index.css
@@ -56,6 +56,7 @@ html, body, .map-container {
     justify-content: center;
     transition: opacity 0.5s ease;
     /*transition: all 0.1s ease;/**/
+    z-index: 10;
 }
 .map .player .background {
     /*background-color:white;*/
@@ -68,6 +69,10 @@ html, body, .map-container {
 }
 .map .player.dead {
     opacity: 0.2;
+    z-index: 1;
+}
+.map .player.active {
+    z-index: 20;
 }
 .map .player.active .background {
     width:120%;


### PR DESCRIPTION
Problem fixed: the dead players icon on the map is overlapping with the alive players