### PR TITLE
Add checkbox to toggle infamous round-thingy

### DIFF
--- a/public/panel.json
+++ b/public/panel.json
@@ -34,6 +34,11 @@
         "name":"display_settings",
         "inputs": [
             {
+                "type": "checkbox",
+                "name": "round_thingy_toggle",
+                "label": "Disable Round Thingy"
+            },
+            {
                 "type": "text",
                 "name": "left_title",
                 "label": "Left box's title"

--- a/src/HUD/MatchBar/TeamScore.tsx
+++ b/src/HUD/MatchBar/TeamScore.tsx
@@ -4,6 +4,7 @@ import WinIndicator from "./WinIndicator";
 import { Timer } from "./MatchBar";
 import TeamLogo from './TeamLogo';
 import PlantDefuse from "../Timers/PlantDefuse"
+import { configs } from "../../App"
 
 interface IProps {
   team: I.Team;
@@ -12,15 +13,30 @@ interface IProps {
   showWin: boolean;
 }
 
-export default class TeamScore extends React.Component<IProps> {
+export default class TeamScore extends React.Component<IProps, {roundThingyToggle: boolean}> {
+  constructor(props: any){
+    super(props);
+    this.state = {
+      roundThingyToggle: false
+    }
+  }
+
+  componentDidMount(){
+    configs.onChange((data:any) =>{
+      if(!data) return;
+      const toggle = data.display_settings.round_thingy_toggle
+      this.setState({roundThingyToggle: toggle})
+    })
+  }
   render() {
     const { orientation, timer, team, showWin } = this.props;
+    const { roundThingyToggle } = this.state;
     return (
       <>
         <div className={`team ${orientation} ${team.side}`}>
           <div className="team-name">{team.name}</div>
           <TeamLogo team={team} />
-          <div className="round-thingy"><div className="inner"></div></div>
+          <div className={`round-thingy ${roundThingyToggle ? 'PepeHands' : ''}`}><div className="inner"></div></div>
         </div>
         <PlantDefuse timer={timer} side={orientation} />
         <WinIndicator team={team} show={showWin}/>

--- a/src/HUD/MatchBar/matchbar.scss
+++ b/src/HUD/MatchBar/matchbar.scss
@@ -178,6 +178,9 @@
 		align-items: center;
 		justify-content: center;
 		border-radius: 50%;
+		&.PepeHands{
+			opacity: 0;
+		}
 		.inner {
 			width: 35px;
 			height: 35px;


### PR DESCRIPTION
We all know that round-thingy is both loved and hated by LHM community. This PR adds a checkbox in HUD settings panel that allows users to disable it without modifying the source code. To be in line with Lexogrine's strict rules on Round Thingies, the round-thingy in question is visible by default. User needs to disable it by checking the checkbox. Checking the checkbox adds appropriately named class 'PepeHands' to round-thingy making it invisible. 